### PR TITLE
update setup.py to also install scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import re
 from setuptools import setup, find_packages
@@ -34,4 +35,5 @@ setup(
             '{0} = {0}:main'.format(__pkg_name__)
         ]
     },
+    scripts = glob.glob('scripts/*')
 )


### PR DESCRIPTION
The scripts located in the `scripts/` subdirectory are currently not getting installed when doing a `pip install ont-bonito`.

This simple change makes sure they do get installed into the `bin/` subdirectory of the installation prefix, alongside the `bonito` command.