### PR TITLE
Use default overlap=2988

### DIFF
--- a/bonito/basecall.py
+++ b/bonito/basecall.py
@@ -39,8 +39,11 @@ def compute_scores(model, batches):
     device = next(model.parameters()).device
 
     with torch.no_grad():
+        use_half = half_supported()
         for chunks in batches:
-            chunks = chunks.type(torch.half).to(device)
+            if use_half:
+                chunks = chunks.type(torch.half)
+            chunks = chunks.to(device)
             posteriors = model(chunks)
             res.append(torch.exp(posteriors).cpu())
     return torch.cat(res), index

--- a/bonito/basecaller.py
+++ b/bonito/basecaller.py
@@ -51,10 +51,17 @@ def main(args):
             tqdm(data, desc="> calling", unit=" reads", leave=False), aligner
         )
     else:
+        try:
+            if not args.overlap is None:
+                overlap = args.overlap
+            else:
+                overlap = model.config['inference']['overlap']
+        except:
+            overlap = 0
         basecalls = basecall(
             model, reads, aligner=aligner,
             beamsize=1 if args.fastq else args.beamsize,
-            chunksize=args.chunksize, overlap=args.overlap,
+            chunksize=args.chunksize, overlap=overlap,
             batchsize=args.batchsize
         )
         writer = Writer(
@@ -76,7 +83,7 @@ def main(args):
 def argparser():
     def check_chunksize(chunksize):
         x = int(chunksize)
-        if x != 3 * (x // 3):
+        if x % 3:
             sys.stderr.write("> Warning: Recommended --chunksize is factor of 3\n")
         return x
 
@@ -93,7 +100,7 @@ def argparser():
     parser.add_argument("--beamsize", default=5, type=int)
     parser.add_argument("--batchsize", default=1, type=int)
     parser.add_argument("--chunksize", default=0, type=check_chunksize)
-    parser.add_argument("--overlap", default=2988, type=int)
+    parser.add_argument("--overlap", type=int)
     parser.add_argument("--skip", action="store_true", default=False)
     parser.add_argument("--fastq", action="store_true", default=False)
     parser.add_argument("--cudart", action="store_true", default=False)

--- a/bonito/basecaller.py
+++ b/bonito/basecaller.py
@@ -74,6 +74,12 @@ def main(args):
 
 
 def argparser():
+    def check_chunksize(chunksize):
+        x = int(chunksize)
+        if x != 3 * (x // 3):
+            sys.stderr.write("> Warning: Recommended --chunksize is factor of 3\n")
+        return x
+
     parser = ArgumentParser(
         formatter_class=ArgumentDefaultsHelpFormatter,
         add_help=False
@@ -86,8 +92,8 @@ def argparser():
     parser.add_argument("--weights", default="0", type=str)
     parser.add_argument("--beamsize", default=5, type=int)
     parser.add_argument("--batchsize", default=1, type=int)
-    parser.add_argument("--chunksize", default=0, type=int)
-    parser.add_argument("--overlap", default=0, type=int)
+    parser.add_argument("--chunksize", default=0, type=check_chunksize)
+    parser.add_argument("--overlap", default=2988, type=int)
     parser.add_argument("--skip", action="store_true", default=False)
     parser.add_argument("--fastq", action="store_true", default=False)
     parser.add_argument("--cudart", action="store_true", default=False)


### PR DESCRIPTION
on master:
```
$ bonito basecaller dna_r9.4.1 reads/test1 --device cpu
AAACAACACATACACACACACACACACACACACACACACACTCTCTCAGTAAATGTGCAGGAAGAAGAGAGACACTATCAATCGAAAACGTATGTAGCTCGAAATTAGGGAGGCAGTAAGTGGGAGGGAGATCTATAAAAGGAAGAAAGAACAGGAAGTTATCCAAGAGAGAGAGATGTATATTGCTCGCGTGCAGAGAGAGAGAGTAGTACATATATATATATATATATATATATATGTGTGTGTGTGTATTTTTAAATCATCGGGTGGAAGCCGGAATAAAAAGCAGGAGATCCCTTTGAAGTAAGTCTCATGATCCATTGCGGGGGTCGTATGCGTGCTGTGGATTAATATAAATGGGTGATCAAAAAAAATTTAGTAAAGGTGAGGCAGCATCATGTATCTCGAGTCCAAAGAAATAATCAAGAGAGAGAGAGATGATAGATAGATCTTGGAGGAGTAAATGAATAATCAAAGA

$ bonito basecaller dna_r9.4.1 reads/test1 --device cpu --chunksize 3600
GGAGAATAAAAAGTCTTGGAGAGAGTAGAAGTGAAGAATCATATCAGAAGAGAAAA

$ bonito basecaller dna_r9.4.1 reads/test1 --device cpu --chunksize 6000
TGAAGGCAGCGATCATGTAATCTCAAGTCCAAAGAAATAATCAAGAGAGAGAGAGATGATAGAAGTAGTTCTTGGAGAGAGATAAATGAAGAATCATATCAGAAGAGAAAA
```

proposed (93% of letters are correct and difference only in last chunk):
```
$ bonito basecaller dna_r9.4.1 reads/test1 --device cpu
AAACAACACATACACACACACACACACACACACACACACACTCTCTCAGTAAATGTGCAGGAAGAAGAGAGACACTATCAATCGAAAACGTATGTAGCTCGAAATTAGGGAGGCAGTAAGTGGGAGGGAGATCTATAAAAGGAAGAAAGAACAGGAAGTTATCCAAGAGAGAGAGATGTATATTGCTCGCGTGCAGAGAGAGAGAGTAGTACATATATATATATATATATATATATATGTGTGTGTGTGTATTTTTAAATCATCGGGTGGAAGCCGGAATAAAAAGCAGGAGATCCCTTTGAAGTAAGTCTCATGATCCATTGCGGGGGTCGTATGCGTGCTGTGGATTAATATAAATGGGTGATCAAAAAAAATTTAGTAAAGGTGAGGCAGCATCATGTATCTCGAGTCCAAAGAAATAATCAAGAGAGAGAGAGATGATAGATAGATCTTGGAGGAGTAAATGAATAATCAAAGA

$ bonito basecaller dna_r9.4.1 reads/test1 --device cpu --chunksize 3600
AAACAACACATACACACACACACACACACACACACACACACTCTCTCAGTAAATGTGCAGGAAGAAGAGAGACACTATCAATCGAAAACGTATGTAGCTCGAAATTAGGGAGGCAGTAAGTGGGAGGGAGATCTATAAAAGGAAGAAAGAACAGGAAGTTATCCAAGAGAGAGAGATGTATATTGCTCGCGTGCAGAGAGAGAGAGTAGTACATATATATATATATATATATATATATGTGTGTGTGTGTATTTTTAAATCATCGGGTGGAAGCCGGAATAAAAAGCAGGAGATCCCTTTGAAGTAAGTCTCATGATCCATTGCGGGGGTCGTATGCGTGCTGTGGATTAATATAAATGGGTGATCAAAAAAAATTTAGTAAAGGTGAGGCAGCATCATGTATCTCGAGTCCAAAGAAATAATCAAGAGAGAGAGAGATGATAGAAGTAGTTCTTGGAGAGAGTGAATGAAAATCTATTCAGAAAGAAAA

$ bonito basecaller dna_r9.4.1 reads/test1 --device cpu --chunksize 6000
AAACAACACATACACACACACACACACACACACACACACACTCTCTCAGTAAATGTGCAGGAAGAAGAGAGACACTATCAATCGAAAACGTATGTAGCTCGAAATTAGGGAGGCAGTAAGTGGGAGGGAGATCTATAAAAGGAAGAAAGAACAGGAAGTTATCCAAGAGAGAGAGATGTATATTGCTCGCGTGCAGAGAGAGAGAGTAGTACATATATATATATATATATATATATATGTGTGTGTGTGTATTTTTAAATCATCGGGTGGAAGCCGGAATAAAAAGCAGGAGATCCCTTTGAAGTAAGTCTCATGATCCATTGCGGGGGTCGTATGCGTGCTGTGGATTAATATAAATGGGTGATCAAAAAAAATTTAGTAAAGGTGAGGCAGCATCATGTATCTCGAGTCCAAAGAAATAATCAAGAGAGAGAGAGATGATAGAAGTAGTTCTTGGAGAGAGATAAATGAAGAATCATATCAGAAGAGAA
```

`2988 = 498 * 6` where 498 is empirically determined number of values which are affected by convolution layers padding.

<details>
<summary>determine_pads.py</summary>

```python
import torch
import numpy as np
from bonito.util import load_model

model = load_model('dna_r9.4.1', 'cpu', weights=0)
model.eval()

inp = np.ones([1, 1, 3600], dtype=np.float32) * 100
out = model(torch.Tensor(inp)).detach().numpy().reshape(-1, 5)
ref_line = out[out.shape[0] // 2]

num = 0
for i, line in enumerate(out):
    if np.max(np.abs(ref_line - line)) == 0.0:
        print(i)
        break
```

</details>