### PR TITLE
Accelerate GPU inference

### DIFF
--- a/bonito/crf/basecall.py
+++ b/bonito/crf/basecall.py
@@ -8,12 +8,11 @@ from kbeam import beamsearch
 from itertools import groupby
 from functools import partial
 from operator import itemgetter
-from prefetch_generator import BackgroundGenerator
 
 from bonito.io import Writer
 from bonito.fast5 import get_reads
 from bonito.aligner import Aligner, align_map
-from bonito.multiprocessing import thread_map
+from bonito.multiprocessing import thread_map, thread_iter
 from bonito.util import concat, chunk, batchify, unbatchify, half_supported
 
 
@@ -101,7 +100,7 @@ def basecall(model, reads, aligner=None, beamsize=40, chunksize=4000, overlap=50
     )
     batches = (
         (read, quantise_int8(compute_scores(model, batch)))
-        for read, batch in BackgroundGenerator(batchify(chunks, batchsize=batchsize))
+        for read, batch in thread_iter(batchify(chunks, batchsize=batchsize))
     )
     stitched = ((read, _stitch(x)) for (read, x) in unbatchify(batches))
     transferred = thread_map(transfer, stitched, n_thread=8, preserve_order=True)

--- a/bonito/crf/basecall.py
+++ b/bonito/crf/basecall.py
@@ -101,7 +101,7 @@ def basecall(model, reads, aligner=None, beamsize=40, chunksize=4000, overlap=50
     )
     batches = (
         (read, quantise_int8(compute_scores(model, batch)))
-         for read, batch in BackgroundGenerator(batchify(chunks, batchsize=batchsize))
+        for read, batch in BackgroundGenerator(batchify(chunks, batchsize=batchsize))
     )
     stitched = ((read, _stitch(x)) for (read, x) in unbatchify(batches))
     transferred = thread_map(transfer, stitched, n_thread=8, preserve_order=True)

--- a/bonito/crf/basecall.py
+++ b/bonito/crf/basecall.py
@@ -8,6 +8,7 @@ from kbeam import beamsearch
 from itertools import groupby
 from functools import partial
 from operator import itemgetter
+from prefetch_generator import BackgroundGenerator
 
 from bonito.io import Writer
 from bonito.fast5 import get_reads
@@ -100,7 +101,7 @@ def basecall(model, reads, aligner=None, beamsize=40, chunksize=4000, overlap=50
     )
     batches = (
         (read, quantise_int8(compute_scores(model, batch)))
-        for read, batch in batchify(chunks, batchsize=batchsize)
+         for read, batch in BackgroundGenerator(batchify(chunks, batchsize=batchsize))
     )
     stitched = ((read, _stitch(x)) for (read, x) in unbatchify(batches))
     transferred = thread_map(transfer, stitched, n_thread=8, preserve_order=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ requests==2.22.0
 crf-beam==0.0.1a0
 ont-fast5-api==3.1.6
 fast-ctc-decode==0.2.5
-prefetch_generator==1.0.1
 #bonito-cuda-runtime==0.0.2a2
 #pyclaragenomics-cuda-10-0==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ requests==2.22.0
 crf-beam==0.0.1a0
 ont-fast5-api==3.1.6
 fast-ctc-decode==0.2.5
+prefetch_generator==1.0.1
 #bonito-cuda-runtime==0.0.2a2
 #pyclaragenomics-cuda-10-0==0.4.2


### PR DESCRIPTION
In the current version of Bonito, the read batches are fetched from a generator object before being transferred to the GPU to perform inference. During this fetch, the GPU is idle. We added a background prefetch that allows the GPU to perform inference while simultaneously fetching the next read batches in the background. This has generated a 10% improvement in overall execution time that scales linearly with the number of reads.    