### PR TITLE
Move `parasail_to_sam` after checking coverage

### DIFF
--- a/bonito/util.py
+++ b/bonito/util.py
@@ -354,13 +354,14 @@ def accuracy(ref, seq, balanced=False, min_coverage=0.0):
     """
     alignment = parasail.sw_trace_striped_32(seq, ref, 8, 4, parasail.dnafull)
     counts = defaultdict(int)
-    _, cigar = parasail_to_sam(alignment, seq)
 
     q_coverage = len(alignment.traceback.query) / len(seq)
     r_coverage = len(alignment.traceback.ref) / len(ref)
 
     if r_coverage < min_coverage:
         return 0.0
+
+    _, cigar = parasail_to_sam(alignment, seq)
 
     for count, op  in re.findall(split_cigar, cigar):
         counts[op] += int(count)


### PR DESCRIPTION
Fix #67

---

**Error message**:
```
Traceback (most recent call last):
  File "/home/x/.local/bin/bonito", line 8, in <module>
    sys.exit(main())
  File "/home/x/.local/lib/python3.5/site-packages/bonito/__init__.py", line 39, in main
    args.func(args)
  File "/home/x/.local/lib/python3.5/site-packages/bonito/cli/train.py", line 84, in main
    model, device, test_loader, criterion=criterion
  File "/home/x/.local/lib/python3.5/site-packages/bonito/training.py", line 212, in test
    accuracy_with_cov(ref, seq) if len(seq) else 0. for ref, seq in zip(refs, seqs)
  File "/home/x/.local/lib/python3.5/site-packages/bonito/training.py", line 212, in <listcomp>
    accuracy_with_cov(ref, seq) if len(seq) else 0. for ref, seq in zip(refs, seqs)
  File "/home/x/.local/lib/python3.5/site-packages/bonito/training.py", line 199, in <lambda>
    accuracy_with_cov = lambda ref, seq: accuracy(ref, seq, min_coverage=min_coverage)
  File "/home/x/.local/lib/python3.5/site-packages/bonito/util.py", line 343, in accuracy
    _, cigar = parasail_to_sam(alignment, seq)
  File "/home/x/.local/lib/python3.5/site-packages/bonito/util.py", line 316, in parasail_to_sam
    first_count, first_op = first.groups()
AttributeError: 'NoneType' object has no attribute 'groups'
```

---

**Cause**: 

In `parasail_to_sam`, **NO** match in `re.search(split_cigar, cigstr)`

https://github.com/nanoporetech/bonito/blob/651b9c14bbac7fb8a1b01db1610dde97eb4d2d76/bonito/util.py#L327-L331

---

**Solution** (not elegant, but minimum changes): Move `parasail_to_sam` after checking coverage. 

If no match in `re.search(split_cigar, cigstr)`, the coverage must be very small.
So move `parasail_to_sam` after checking coverage will prevent call the `parasail_to_sam`.
