### PR TITLE
fix recursive option to work with symlinks

### DIFF
--- a/bonito/fast5.py
+++ b/bonito/fast5.py
@@ -3,6 +3,7 @@ Bonito Fast5 Utils
 """
 
 import sys
+from glob import glob
 from pathlib import Path
 from functools import partial
 from multiprocessing import Pool
@@ -185,7 +186,7 @@ def get_reads(directory, read_ids=None, skip=False, max_read_size=0, n_proc=1, r
     pattern = "**/*.fast5" if recursive else "*.fast5"
     get_filtered_reads = partial(get_read_ids, read_ids=read_ids, skip=skip)
     with Pool(n_proc) as pool:
-        for job in chain(pool.imap(get_filtered_reads, Path(directory).glob(pattern))):
+        for job in chain(pool.imap(get_filtered_reads, (Path(x) for x in glob(directory + "/" + pattern, recursive=True)))):
             for read in pool.imap(get_raw_data_for_read, job):
                 if max_read_size > 0 and len(read.signal) > max_read_size:
                     sys.stderr.write(


### PR DESCRIPTION
`Path.glob` doesn't work with `**` and symlinks
https://stackoverflow.com/questions/46529760/getting-glob-to-follow-symlinks-in-python

If you use recursive option and some of the directories in the parent directory are symlinks, Bonito won't find the fast5s. Using `glob.glob` with `recursive=True` fixes this.