### PR TITLE
slow5 integration for basecaller module

### DIFF
--- a/bonito/cli/basecaller.py
+++ b/bonito/cli/basecaller.py
@@ -86,7 +86,7 @@ def main(args):
     if fmt.name != 'fastq':
         groups = get_read_groups(
             args.reads_directory, args.model_directory,
-            n_proc=8, recursive=args.recursive,
+            n_proc=args.procs, recursive=args.recursive,
             read_ids=column_to_set(args.read_ids), skip=args.skip,
             cancel=process_cancel()
         )
@@ -94,9 +94,9 @@ def main(args):
         groups = []
 
     reads = get_reads(
-        args.reads_directory, n_proc=8, recursive=args.recursive,
+        args.reads_directory, n_proc=args.procs, recursive=args.recursive,
         read_ids=column_to_set(args.read_ids), skip=args.skip,
-        cancel=process_cancel()
+        cancel=process_cancel(), use_slow5=args.slow5, slow5_threads=args.slow5_threads, slow5_batchsize=args.slow5_batchsize
     )
 
     if args.max_reads:
@@ -154,6 +154,10 @@ def argparser():
     )
     parser.add_argument("model_directory")
     parser.add_argument("reads_directory")
+    parser.add_argument("--slow5", action="store_true", default=False)
+    parser.add_argument("--slow5_threads", default=4, type=int)
+    parser.add_argument("--procs", default=8, type=int)
+    parser.add_argument("--slow5_batchsize", default=4096, type=int)
     parser.add_argument("--reference")
     parser.add_argument("--modified-bases", nargs="+")
     parser.add_argument("--modified-base-model")

--- a/requirements-cuda111.txt
+++ b/requirements-cuda111.txt
@@ -16,3 +16,4 @@ fast-ctc-decode==0.3.2
 python-dateutil==2.8.2
 # cuda requirements
 torch==1.11+cu111
+pyslow5==0.5.0a1

--- a/requirements-cuda113.txt
+++ b/requirements-cuda113.txt
@@ -16,3 +16,4 @@ fast-ctc-decode==0.3.2
 python-dateutil==2.8.2
 # cuda requirements
 torch==1.11+cu113
+pyslow5==0.5.0a1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ fast-ctc-decode==0.3.2
 python-dateutil==2.8.2
 # cuda requirements
 torch~=1.11
+pyslow5==0.5.0a1


### PR DESCRIPTION
### Initial slow5 integration for **bonito basecaller** module

This is the basic integration of slow5 into bonito. It currently works for the basecaller module, using `seq_reads_multi()` from the pyslow5 library.
Random access can easily be added with  `get_read()` and `get_read_list_multi()` for the other bonito modules.

A few flags are added as well:

- "--slow5", action="store_true", default=False: expect slow5/blow5 files rather than fast5 for input
- "--slow5_threads", default=4 :  number of threads to use in pyslow5 (threads handled on C side of library)
- "--procs", default=8 : number of processors to use in bonito (have not tested altering these, and kept default for testing)
- "--slow5_batchsize", default=4096 : batch size to use for memory management with slow5. Larger batchsize uses more RAM

### Installing

```bash
python3.8 -m venv s5py
source s5py/bin/activate
pip install --upgrade pip

git clone https://github.com/Psy-Fer/bonito.git
cd bonito
pip install -r requirements.txt
python setup.py develop

bonito --help
```

### Benchmarking

Bonito results will show that for a single sample BLOW5 and FAST5 give similar runtime as FAST5 multiprocessing is implemented. However, we show that FAST5 multiprocessing is not scalable beyond a few samples as random accesses quickly saturate the disk system capability, whereas sequential I/O in BLOW5 is very lightweight and allows scalability over dozens of samples.
 
When the disk system is solely allocated for Bonito:
FAST5: 31.5 min 
SLOW5: 28 min

On a GPU server with 4 Tesla V100s and 40 cores reading data from a mounted NAS, we executed four instances of FAST5 basecalling and SLOW5 basecalling in parallel. FAST5 instances took around 1 hour whereas SLOW5 instances took 30 mins. This shows that SLOW5 is lightweight and can scale up.

**FAST5 times:**
1:03:40
1:05:44
1:06:02
1:04:40
**SLOW5 times:**
32:39.06
32:59.78
32:40.15
32:51.6

When the disk system is under extreme load (represents a scenario where we basecall hundreds of samples on an local cluster). Simulated scenario by running fio to introduce a huge disk I/O load.
FAST5: 15 hours
SLOW5: 52 min

Commands used for benchmarking

(yes, mem cache was cleared between all benchmarks)

```bash
bonito basecaller --batchsize 2048 -v dna_r9.4.1_e8.1_fast@v3.4 fast5/NA12878_SRE/20201027_0537_3A_PAF25452_97d631c6/fast5_pass/  --device cuda > a.fastq

bonito basecaller --batchsize 2048 -v dna_r9.4.1_e8.1_fast@v3.4 slow5_merged/ --slow5 --slow5_threads 8 --slow5_batchsize 4096 --device cuda  > b.fastq

# synthetic workload to represent basecalling hundreds of samples in parallel:

fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --filename=test --bs=100k --iodepth=32 --size=16G --readwrite=randread
```

![image](https://user-images.githubusercontent.com/8985577/165270903-145ea9ea-e9aa-47cf-9ec0-3c37ec63fee7.png)

This figure with up to 8 parallel runs shows how slow5 scales better than fast5.

By increasing the speed by which a basecaller can process multiple parallel jobs, we can save users time, and if running on cloud infrastructure, a lot of money. This also shows how slow5 could increase the number of flowcells the basecallers could "keep up" with. (see also our guppy modifications)

