### PR TITLE
Suppress warning and add progress bar for `bonito convert`

### DIFF
--- a/bonito/cli/convert.py
+++ b/bonito/cli/convert.py
@@ -110,13 +110,13 @@ def main(args):
     training, validation = validation_split(reads, args.validation_reads)
 
     print("> preparing training chunks\n")
-    training_chunks = chunk_dataset(training, args.chunksize)
+    training_chunks = chunk_dataset(training, args.chunksize, len(training))
     training_indices = typical_indices(training_chunks.lengths)
     training_chunks = filter_chunks(training_chunks, np.random.permutation(training_indices))
     save_chunks(training_chunks, args.output_directory)
 
     print("\n> preparing validation chunks\n")
-    validation_chunks = chunk_dataset(validation, args.chunksize)
+    validation_chunks = chunk_dataset(validation, args.chunksize, len(validation))
     validation_indices = typical_indices(validation_chunks.lengths)
     validation_chunks = filter_chunks(validation_chunks, validation_indices)
     save_chunks(validation_chunks, os.path.join(args.output_directory, "validation"))

--- a/bonito/cli/convert.py
+++ b/bonito/cli/convert.py
@@ -73,7 +73,7 @@ def chunk_dataset(reads, chunk_len, num_chunks=None):
 
 
 def validation_split(reads, num_valid=1000):
-    reads = np.random.permutation(sorted(reads.items()))
+    reads = np.random.permutation(np.array(list(reads.items()), dtype=object))
     return OrderedDict(reads[:-num_valid]), OrderedDict(reads[-num_valid:])
 
 


### PR DESCRIPTION
## Modifications
- Suppress `VisibleDeprecationWarning` in  [`nep-0034`](https://numpy.org/neps/nep-0034-infer-dtype-is-object.html)
- When numpy version >= 1.24.0, this might 
  - fix #347 
  - fix #355 
- Add progress bar for `tqdm`

## Message
- Also shown in #285 

```
bonito/cli/convert.py:76: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-
tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify
'dtype=object' when creating the ndarray.
  reads = np.random.permutation(sorted(reads.items()))
> preparing training chunks

36050496it [03:34, 167773.82it/s]
```

https://github.com/nanoporetech/bonito/blob/62050ba32fac20b1e82f1349aaaaf41512a7008c/bonito/cli/convert.py#L65-L72