### PR TITLE
Show more info in `bonito view` for v3 model

### DIFF
--- a/bonito/nn.py
+++ b/bonito/nn.py
@@ -180,6 +180,10 @@ class LinearCRFEncoder(Module):
             }
         return res
 
+    def extra_repr(self):
+        return 'n_base={}, state_len={}, scale={}, blank_score={}, expand_blanks={}'.format(
+            self.n_base, self.state_len, self.scale, self.blank_score, self.expand_blanks
+        )
 
 @register
 class Permute(Module):
@@ -193,6 +197,9 @@ class Permute(Module):
 
     def to_dict(self, include_weights=False):
         return {'dims': self.dims}
+
+    def extra_repr(self):
+        return 'dims={}'.format(self.dims)
 
 
 def truncated_normal(size, dtype=torch.float32, device=None, num_resample=5):
@@ -239,6 +246,9 @@ class RNNWrapper(Module):
             if 'bias_hh' in name:
                 x.requires_grad = False
                 x.zero_()
+
+    def extra_repr(self):
+        return 'reverse={}'.format(bool(self.reverse))
 
 
 @register


### PR DESCRIPTION
-  Adding `extra_repr` in `Permute`, `RNNWrapper`, and `LinearCRFEncoder`

---

**Command:**
```bash
bonito view dna_r9.4.1@v3.1.toml
```

**Output:**
```diff
Model(
  (encoder): Serial(
    (0): Convolution(
      (conv): Conv1d(1, 4, kernel_size=(5,), stride=(1,), padding=(2,))
      (activation): Swish()
    )
    (1): Convolution(
      (conv): Conv1d(4, 16, kernel_size=(5,), stride=(1,), padding=(2,))
      (activation): Swish()
    )
    (2): Convolution(
      (conv): Conv1d(16, 768, kernel_size=(19,), stride=(5,), padding=(9,))
      (activation): Swish()
    )
-    (3): Permute()
+    (3): Permute(dims=[2, 0, 1])
     (4): LSTM(
+      reverse=True
       (rnn): LSTM(768, 768)
     )
     (5): LSTM(
+      reverse=False
       (rnn): LSTM(768, 768)
     )
     (6): LSTM(
+      reverse=True
       (rnn): LSTM(768, 768)
     )
     (7): LSTM(
+      reverse=False
       (rnn): LSTM(768, 768)
     )
     (8): LSTM(
+      reverse=True
       (rnn): LSTM(768, 768)
     )
     (9): LinearCRFEncoder(
+      n_base=4, state_len=5, scale=5.0, blank_score=2.0, expand_blanks=True
       (linear): Linear(in_features=768, out_features=4096, bias=True)
       (activation): Tanh()
     )
  )
)
Total parameters in model 27008104
```
